### PR TITLE
Update StartingActivity.java

### DIFF
--- a/app/src/main/java/com/example/plarent/blockchain/activity/StartingActivity.java
+++ b/app/src/main/java/com/example/plarent/blockchain/activity/StartingActivity.java
@@ -193,7 +193,7 @@ public class StartingActivity extends AppCompatActivity {
 //      String private_key = "9f684227f1de663775848b3db656bca685e085391e2b00b0e115679fd45443ef58a5abeb555ab3d5f7a3cd27955a2079e5fd486743f36515c8e5bea07992100b";
         String url = "http://poc.serval.uni.lu:8080/api/services/cryptocurrency/v1/wallets";
         String jsonFile =
-                "{ \"body\": {\"pub_key\":\"" + public_k+ "\",\"name\": \"Plarent\" }, \"network_id\": 0, \"protocol_version\": 0, \"service_id\": 1, \"message_id\": 0, \"signature\": \""+private_k+"\"}";
+                "{ \"body\": {\"pub_key\":\"" + public_key + "\",\"name\": \"Plarent\" }, \"network_id\": 0, \"protocol_version\": 0, \"service_id\": 1, \"message_id\": 0, \"signature\": \""+private_k+"\"}";
         JSONObject jsonObject = new JSONObject(jsonFile);
         try {
             startProcess(url, jsonObject.toString());

--- a/app/src/main/java/com/example/plarent/blockchain/activity/StartingActivity.java
+++ b/app/src/main/java/com/example/plarent/blockchain/activity/StartingActivity.java
@@ -187,8 +187,10 @@ public class StartingActivity extends AppCompatActivity {
     }
 
     private void generateWallet() throws JSONException {
-        String public_key = "6ce29b2d3ecadc434107ce52c287001c968a1b6eca3e5a1eb62a2419e2924b85";
-        String private_key = "9f684227f1de663775848b3db656bca685e085391e2b00b0e115679fd45443ef58a5abeb555ab3d5f7a3cd27955a2079e5fd486743f36515c8e5bea07992100b";
+        String public_key = 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a';
+        String private_key = '978e3321bd6331d56e5f4c2bdb95bf471e95a77a6839e68d4241e7b0932ebe2b' + 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a';
+//      String public_key = "6ce29b2d3ecadc434107ce52c287001c968a1b6eca3e5a1eb62a2419e2924b85";
+//      String private_key = "9f684227f1de663775848b3db656bca685e085391e2b00b0e115679fd45443ef58a5abeb555ab3d5f7a3cd27955a2079e5fd486743f36515c8e5bea07992100b";
         String url = "http://poc.serval.uni.lu:8080/api/services/cryptocurrency/v1/wallets";
         String jsonFile =
                 "{ \"body\": {\"pub_key\":\"" + public_k+ "\",\"name\": \"Plarent\" }, \"network_id\": 0, \"protocol_version\": 0, \"service_id\": 1, \"message_id\": 0, \"signature\": \""+private_k+"\"}";


### PR DESCRIPTION
* Changes the keys to one that are hardcoded and, in theory, should should fine.
* The `keygen` is using algorithm `Ed25519` that are to be in the range of (32-64 bytes) i.e. 32 for public key, 64 for secret (32 secrete concatenated with 32 of public key).
* Generated using `(Tweetnacl-js)[https://github.com/dchest/tweetnacl-js]`.
* TODO - If this fails, try with other library including `(ED25519-Java)[https://github.com/str4d/ed25519-java]`.

* CHECK - the signature field in the JSON requires to be signature generated from signing the transaction data using the private key and no the full private key. Which means, that you need to take the data (consisting of `pub_key` and `name` with the information of `service_id`, `protocol_version` and `network_id`) and perform the signature function `sign(private_key, data)`. The output of this function goes int he signature filed of the JSON.